### PR TITLE
Introduce support for continuous access evaluation capable token

### DIFF
--- a/BARK.ps1
+++ b/BARK.ps1
@@ -85,7 +85,11 @@ Function Get-AZRefreshTokenWithUsernamePassword {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $TenantID
+        $TenantID,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
 
     $ClientID = "1b730954-1685-4b74-9bfd-dac224a7b894"
@@ -97,6 +101,11 @@ Function Get-AZRefreshTokenWithUsernamePassword {
         Password      =   $Password
         Client_ID     =   $ClientID
         
+    }
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
     }
 
     $Token = Invoke-RestMethod `
@@ -126,7 +135,11 @@ Function Get-MSGraphTokenWithUsernamePassword {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $TenantID
+        $TenantID,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
 
     $ClientID = "1b730954-1685-4b74-9bfd-dac224a7b894"
@@ -138,6 +151,11 @@ Function Get-MSGraphTokenWithUsernamePassword {
         Password      =   $Password
         Client_ID     =   $ClientID
         
+    }
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
     }
 
     $Token = Invoke-RestMethod `
@@ -167,7 +185,11 @@ Function Get-ARMTokenWithUsernamePassword {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $TenantID
+        $TenantID,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
 
     $ClientID = "1b730954-1685-4b74-9bfd-dac224a7b894"
@@ -179,6 +201,11 @@ Function Get-ARMTokenWithUsernamePassword {
         Password      =   $Password
         Client_ID     =   $ClientID
         
+    }
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
     }
 
     $Token = Invoke-RestMethod `
@@ -208,7 +235,11 @@ Function Get-MSGraphTokenWithClientCredentials {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $TenantName
+        $TenantName,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
 
     $Body = @{
@@ -216,6 +247,11 @@ Function Get-MSGraphTokenWithClientCredentials {
         Scope           =   "https://graph.microsoft.com/.default"
         client_Id       =   $ClientID
         Client_Secret   =   $ClientSecret
+    }
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
     }
 
     $Token = Invoke-RestMethod `
@@ -243,7 +279,11 @@ Function Get-MSGraphTokenWithRefreshToken {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $TenantID
+        $TenantID,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
 
     $Body = @{
@@ -251,6 +291,11 @@ Function Get-MSGraphTokenWithRefreshToken {
         "refresh_token" =   $RefreshToken
         "scope"         =   "openid"
         "resource"      =   "https://graph.microsoft.com"
+    }
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
     }
 
     $Token = Invoke-RestMethod `
@@ -286,7 +331,11 @@ Function Get-MSGraphTokenWithPortalAuthRefreshToken {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $PortalID
+        $PortalID,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
 
     $Body = @{
@@ -295,6 +344,11 @@ Function Get-MSGraphTokenWithPortalAuthRefreshToken {
         tenant = $TenantID
         portalAuthorization = $PortalAuthRefreshToken
         altPortalAuthorization = $AltPortalAuthRefreshToken
+    }
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
     }
 
     $WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
@@ -333,7 +387,11 @@ Function Get-ARMTokenWithPortalAuthRefreshToken {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $TenantID
+        $TenantID,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
 
     $Body = @{
@@ -342,6 +400,11 @@ Function Get-ARMTokenWithPortalAuthRefreshToken {
         tenant = $TenantID
         portalAuthorization = $PortalAuthRefreshToken
         altPortalAuthorization = $AltPortalAuthRefreshToken
+    }
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
     }
 
     $WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
@@ -378,7 +441,11 @@ Function Get-AzureRMTokenWithClientCredentials {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $TenantName
+        $TenantName,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
 
     $Body = @{
@@ -386,6 +453,11 @@ Function Get-AzureRMTokenWithClientCredentials {
         Scope           =   "https://management.azure.com/.default"
         client_Id       =   $ClientID
         Client_Secret   =   $ClientSecret
+    }
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
     }
 
     $Token = Invoke-RestMethod `
@@ -413,8 +485,17 @@ Function Get-ARMTokenWithRefreshToken {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $TenantID
+        $TenantID,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
+    }
 
     $Body = @{
         "grant_type"    =   "refresh_token"
@@ -448,8 +529,17 @@ Function Get-AzurePortalTokenWithRefreshToken {
 
         [Parameter(Mandatory = $True)]
         [string]
-        $TenantID
+        $TenantID,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]
+        $UseCAE
     )
+
+    if ($UseCAE) {
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+        $Body.Add("claims", $Claims)
+    }
 
     $Body = @{
         "grant_type"    =   "refresh_token"


### PR DESCRIPTION
Access token that are requested using the continuous access evaluation are valid for about 24 hours, but can be revoked by the tenant administrator.

CAE is implemented by adding the `claims` claim with the following client capabilities to the request.

```json
{
  "access_token": {
    "xms_cc": {
      "values": "cp1"
    }
  }
}
```

More on CAE and it's implications
* https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/concept-continuous-access-evaluation
* https://cloudbrothers.info/en/continuous-access-elevation/